### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <thrift.version>917130</thrift.version>
         <antlr.version>3.1.3</antlr.version>
         <common.cli.version>1.1</common.cli.version>
-        <common.collections.version>3.2.1</common.collections.version>
+        <common.collections.version>3.2.2</common.collections.version>
         <common.lang.version>2.4</common.lang.version>
         <hadoop.version>0.20.1</hadoop.version>
         <google.collections.version>1.0</google.collections.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
